### PR TITLE
Allow configuration of base URL and Service/JSONService path params.

### DIFF
--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -15,9 +15,6 @@ module VSafe
   class Client
     SANDBOX_FINGERPRINT_PATH = "ThreatMetrixUIRedirector".freeze
     FINGERPRINT_PATH = "PaySafeUIRedirector".freeze
-    # We should only use JSONP_SERVICE_PATH for charge_acct_to_tempory_token call in web js.
-    JSONP_SERVICE_PATH = "GatewayProxyJSON/Service".freeze
-    SERVICE_PATH = "GatewayProxy/Service".freeze
     REQUEST_CONTENT_TYPE = "application/json; charset=utf-8".freeze
 
     attr_reader :config
@@ -64,7 +61,7 @@ module VSafe
     def service_url(endpoint = nil, jsonp = false)
       parts = [
         config.url,
-        jsonp ? JSONP_SERVICE_PATH : SERVICE_PATH
+        jsonp ? config.jsonp_service_path : config.service_path
       ]
       parts << endpoint if endpoint
 

--- a/lib/vsafe/config.rb
+++ b/lib/vsafe/config.rb
@@ -3,20 +3,30 @@ module VSafe
     DEFAULT_REQUEST_TIMEOUT = 20 # seconds
     DEFAULT_SANDBOX_URL = "https://paysafesandbox.ecustomersupport.com".freeze
     DEFAULT_PRODUCTION_URL = "https://paysafe.ecustomerpayments.com".freeze
+    DEFAULT_JSONP_SERVICE_PATH = "GatewayProxyJSON/Service".freeze
+    DEFAULT_SERVICE_PATH = "GatewayProxy/Service".freeze
 
-    attr_accessor :sandbox,
+    attr_accessor :sandbox_url,
+                  :production_url,
+                  :sandbox,
                   :account_name,
                   :password,
+                  :service_path,
+                  :jsonp_service_path,
                   :request_timeout
 
     def initialize
       # Set sandbox to true by default
       @sandbox = true
+      @service_path = DEFAULT_SERVICE_PATH
+      @jsonp_service_path = DEFAULT_JSONP_SERVICE_PATH
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
+      @sandbox_url = DEFAULT_SANDBOX_URL
+      @production_url = DEFAULT_PRODUCTION_URL
     end
 
     def url
-      sandbox ? DEFAULT_SANDBOX_URL : DEFAULT_PRODUCTION_URL
+      sandbox ? @sandbox_url : @production_url
     end
   end
 end

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -150,14 +150,34 @@ RSpec.describe VSafe::Client do
     end
 
     context "when jsonp is false" do
-      let(:service_path) { VSafe::Client::SERVICE_PATH }
+      let(:service_path) { VSafe::Config::DEFAULT_SERVICE_PATH }
 
       it_behaves_like "returns url"
     end
 
     context "when jsonp is true" do
-      let(:service_path) { VSafe::Client::JSONP_SERVICE_PATH }
+      let(:service_path) { VSafe::Config::DEFAULT_JSONP_SERVICE_PATH }
 
+      it_behaves_like "returns url", true
+    end
+
+    context 'when custom service_path is set' do
+      let(:service_path) { '__custom_service' }
+      let(:client) {
+        VSafe::Client.new do |config|
+          config.service_path = '__custom_service'
+        end
+      }
+      it_behaves_like "returns url"
+    end
+
+    context 'when custom jsonp_service_path is set' do
+      let(:service_path) { '__custom_jsonp' }
+      let(:client) {
+        VSafe::Client.new do |config|
+          config.jsonp_service_path = '__custom_jsonp'
+        end
+      }
       it_behaves_like "returns url", true
     end
   end

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -161,23 +161,25 @@ RSpec.describe VSafe::Client do
       it_behaves_like "returns url", true
     end
 
-    context 'when custom service_path is set' do
-      let(:service_path) { '__custom_service' }
+    context "when custom service_path is set" do
+      let(:service_path) { "__custom_service" }
       let(:client) {
         VSafe::Client.new do |config|
-          config.service_path = '__custom_service'
+          config.service_path = "__custom_service"
         end
       }
+
       it_behaves_like "returns url"
     end
 
-    context 'when custom jsonp_service_path is set' do
-      let(:service_path) { '__custom_jsonp' }
+    context "when custom jsonp_service_path is set" do
+      let(:service_path) { "__custom_jsonp" }
       let(:client) {
         VSafe::Client.new do |config|
-          config.jsonp_service_path = '__custom_jsonp'
+          config.jsonp_service_path = "__custom_jsonp"
         end
       }
+
       it_behaves_like "returns url", true
     end
   end

--- a/spec/vsafe/config_spec.rb
+++ b/spec/vsafe/config_spec.rb
@@ -3,6 +3,7 @@ require "vsafe/config"
 
 RSpec.describe VSafe::Config do
   let (:config) { VSafe::Config.new }
+  
   describe ".new" do
     it "sets default configs" do
       expect(config.sandbox).to eq(true)
@@ -10,26 +11,31 @@ RSpec.describe VSafe::Config do
       expect(config.url).not_to be_empty
     end
   end
-  describe '#url' do
-    context 'sandbox is true' do
-      it 'uses default sandbox_url' do
+  
+  describe "#url" do
+    context "sandbox is true" do
+      it "uses default sandbox_url" do
         expect(config.url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
       end
-      it 'uses custom sandbox_url when sandbox' do
-        config.sandbox_url = 'https://www.google.com'
-        expect(config.url).to eq('https://www.google.com')
+      
+      it "uses custom sandbox_url when sandbox" do
+        config.sandbox_url = "https://www.google.com"
+        expect(config.url).to eq("https://www.google.com")
       end
     end
-    context 'sandbox is not true' do
+    
+    context "sandbox is not true" do
       before do
         config.sandbox = false
       end
-      it 'uses default production_url when not sandbox' do
+      
+      it "uses default production_url when not sandbox" do
         expect(config.url).to eq(VSafe::Config::DEFAULT_PRODUCTION_URL)
       end
-      it 'uses custom production_url when not sandbox' do
-        config.production_url = 'https://www.google.com'
-        expect(config.url).to eq('https://www.google.com')
+      
+      it "uses custom production_url when not sandbox" do
+        config.production_url = "https://www.google.com"
+        expect(config.url).to eq("https://www.google.com")
       end
     end
   end

--- a/spec/vsafe/config_spec.rb
+++ b/spec/vsafe/config_spec.rb
@@ -2,13 +2,35 @@ require "spec_helper"
 require "vsafe/config"
 
 RSpec.describe VSafe::Config do
+  let (:config) { VSafe::Config.new }
   describe ".new" do
     it "sets default configs" do
-      config = VSafe::Config.new
-
       expect(config.sandbox).to eq(true)
       expect(config.request_timeout).to be_a(Fixnum)
       expect(config.url).not_to be_empty
+    end
+  end
+  describe '#url' do
+    context 'sandbox is true' do
+      it 'uses default sandbox_url' do
+        expect(config.url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
+      end
+      it 'uses custom sandbox_url when sandbox' do
+        config.sandbox_url = 'https://www.google.com'
+        expect(config.url).to eq('https://www.google.com')
+      end
+    end
+    context 'sandbox is not true' do
+      before do
+        config.sandbox = false
+      end
+      it 'uses default production_url when not sandbox' do
+        expect(config.url).to eq(VSafe::Config::DEFAULT_PRODUCTION_URL)
+      end
+      it 'uses custom production_url when not sandbox' do
+        config.production_url = 'https://www.google.com'
+        expect(config.url).to eq('https://www.google.com')
+      end
     end
   end
 end


### PR DESCRIPTION
These base URLs and paths vary by vesta partner. Our domain is different and our service paths are slightly different. This PR moves those items into the config, but sets all the defaults to the old values so there _should_ be no affect to existing users unless they were doing things like accessing `Client::JSONP_SERVICE_PATH` 
