### PR TITLE
Make Vesta URL config explicit and add optional logger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ client = VSafe::Client.new do |config|
 end
 ```
 
+### Vesta URLs
+
+All four Vesta URLs can be specified in config:
+
+```ruby
+VSafe.configure do |config|
+  config.sandbox_url = 'https://my.sandbox.url/GatewayV4Proxy/Service'
+  config.sandbox_jsonp_url = 'https://my.sandboxtoken.url/GatewayV4ProxyJSON/Service'
+  config.production_url = 'https://my.production.url/GatewayV4Proxy/Service'
+  config.production_jsonp_url = 'https://my.production.url/GatewayV4ProxyJSON/Service'
+end
+```
+
+### Logging
+
+The logger passed to HTTParty can be specified in config:
+
+```ruby
+VSafe.configure do |config|
+  config.logger = Rails.logger
+end
+```
+
 ## Request & Response
 
 First, Setup a client for making request:

--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -83,7 +83,8 @@ module VSafe
         ).to_json,
         headers: {
           "Content-Type" => REQUEST_CONTENT_TYPE
-        }
+        },
+        logger: @config.logger
       }
 
       # The HTTPS endpoint for VSafe Sandbox has an outdated SSL version.

--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -60,7 +60,7 @@ module VSafe
 
     def service_url(endpoint = nil, jsonp = false)
       parts = [
-        config.url,
+        jsonp ? config.jsonp_url : config.url,
         jsonp ? config.jsonp_service_path : config.service_path
       ]
       parts << endpoint if endpoint
@@ -69,7 +69,7 @@ module VSafe
     end
 
     def fingerprint_url
-      @_fingerprint_url ||= URI.join(config.url, config.sandbox ? SANDBOX_FINGERPRINT_PATH : FINGERPRINT_PATH).to_s
+      @_fingerprint_url ||= URI.join(config.jsonp_url, config.sandbox ? SANDBOX_FINGERPRINT_PATH : FINGERPRINT_PATH).to_s
     end
 
     private

--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -59,17 +59,13 @@ module VSafe
     end
 
     def service_url(endpoint = nil, jsonp = false)
-      parts = [
-        jsonp ? config.jsonp_url : config.url,
-        jsonp ? config.jsonp_service_path : config.service_path
-      ]
-      parts << endpoint if endpoint
-
-      File.join(parts)
+      base_uri = jsonp ? config.jsonp_url : config.url
+      endpoint.nil? ? base_uri : File.join(base_uri, endpoint)
     end
 
     def fingerprint_url
-      @_fingerprint_url ||= URI.join(config.jsonp_url, config.sandbox ? SANDBOX_FINGERPRINT_PATH : FINGERPRINT_PATH).to_s
+      base_uri = URI.join(config.jsonp_url, '/')
+      @_fingerprint_url ||= URI.join(base_uri, config.sandbox ? SANDBOX_FINGERPRINT_PATH : FINGERPRINT_PATH).to_s
     end
 
     private

--- a/lib/vsafe/config.rb
+++ b/lib/vsafe/config.rb
@@ -23,6 +23,8 @@ module VSafe
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @sandbox_url = DEFAULT_SANDBOX_URL
       @production_url = DEFAULT_PRODUCTION_URL
+      @sandbox_jsonp_url = DEFAULT_SANDBOX_JSONP_URL
+      @production_jsonp_url = DEFAULT_PRODUCTION_JSONP_URL
     end
 
     def url
@@ -30,7 +32,7 @@ module VSafe
     end
 
     def jsonp_url
-      sandbox ? (@sandbox_jsonp_url || @sandbox_url) : (@production_jsonp_url || @production_url)
+      sandbox ? @sandbox_jsonp_url : @production_jsonp_url
     end
   end
 end

--- a/lib/vsafe/config.rb
+++ b/lib/vsafe/config.rb
@@ -1,10 +1,11 @@
 module VSafe
   class Config
     DEFAULT_REQUEST_TIMEOUT = 20 # seconds
-    DEFAULT_SANDBOX_URL = "https://paysafesandbox.ecustomersupport.com".freeze
-    DEFAULT_PRODUCTION_URL = "https://paysafe.ecustomerpayments.com".freeze
-    DEFAULT_JSONP_SERVICE_PATH = "GatewayProxyJSON/Service".freeze
-    DEFAULT_SERVICE_PATH = "GatewayProxy/Service".freeze
+    DEFAULT_SANDBOX_URL = "https://paysafesandbox.ecustomersupport.com/GatewayProxy/Service".freeze
+    DEFAULT_SANDBOX_JSONP_URL = "https://paysafesandbox.ecustomersupport.com/GatewayProxyJSON/Service".freeze
+
+    DEFAULT_PRODUCTION_URL = "https://paysafe.ecustomerpayments.com/GatewayProxy/Service".freeze
+    DEFAULT_PRODUCTION_JSONP_URL = "https://paysafe.ecustomerpayments.com/GatewayProxyJSON/Service".freeze
 
     attr_accessor :sandbox_url,
                   :production_url,
@@ -13,16 +14,12 @@ module VSafe
                   :sandbox,
                   :account_name,
                   :password,
-                  :service_path,
-                  :jsonp_service_path,
                   :request_timeout,
                   :logger
 
     def initialize
       # Set sandbox to true by default
       @sandbox = true
-      @service_path = DEFAULT_SERVICE_PATH
-      @jsonp_service_path = DEFAULT_JSONP_SERVICE_PATH
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @sandbox_url = DEFAULT_SANDBOX_URL
       @production_url = DEFAULT_PRODUCTION_URL

--- a/lib/vsafe/config.rb
+++ b/lib/vsafe/config.rb
@@ -8,6 +8,8 @@ module VSafe
 
     attr_accessor :sandbox_url,
                   :production_url,
+                  :sandbox_jsonp_url,
+                  :production_jsonp_url,
                   :sandbox,
                   :account_name,
                   :password,
@@ -27,6 +29,10 @@ module VSafe
 
     def url
       sandbox ? @sandbox_url : @production_url
+    end
+
+    def jsonp_url
+      sandbox ? (@sandbox_jsonp_url || @sandbox_url) : (@production_jsonp_url || @production_url)
     end
   end
 end

--- a/lib/vsafe/config.rb
+++ b/lib/vsafe/config.rb
@@ -15,7 +15,8 @@ module VSafe
                   :password,
                   :service_path,
                   :jsonp_service_path,
-                  :request_timeout
+                  :request_timeout,
+                  :logger
 
     def initialize
       # Set sandbox to true by default

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -191,7 +191,14 @@ RSpec.describe VSafe::Client do
       end
 
       it "returns url" do
-        expect(client.fingerprint_url).to eq("#{client.config.url}/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
+        expect(client.fingerprint_url).to eq("#{client.config.jsonp_url}/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
+      end
+
+      it "uses the jsonp_url when set" do
+        allow(client.config).to receive(:sandbox_jsonp_url).and_return('https://google.com/')
+        puts "sandbox_jsonp_url:  #{client.config.sandbox_jsonp_url}"
+        puts "URL:  #{client.config.jsonp_url}  #{client.config.sandbox}"
+        expect(client.fingerprint_url).to eq("https://google.com/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
       end
     end
 
@@ -201,7 +208,8 @@ RSpec.describe VSafe::Client do
       end
 
       it "returns url" do
-        expect(client.fingerprint_url).to eq("#{client.config.url}/#{VSafe::Client::FINGERPRINT_PATH}")
+        allow(client.config).to receive(:jsonp_url).and_return('https://google.com/')
+        expect(client.fingerprint_url).to eq("https://google.com/#{VSafe::Client::FINGERPRINT_PATH}")
       end
     end
   end

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe VSafe::Client do
         let(:endpoint) { "foo" }
 
         it "returns endpoint url" do
-          expect(client.service_url(endpoint, jsonp)).to eq("#{client.config.url}/#{endpoint}")
+          expect(client.service_url(endpoint, jsonp)).to eq("#{base_uri}/#{endpoint}")
         end
       end
 
@@ -144,16 +144,24 @@ RSpec.describe VSafe::Client do
         let(:endpoint) { nil }
 
         it "returns base url" do
-          expect(client.service_url(endpoint, jsonp)).to eq(client.config.url)
+          expect(client.service_url(endpoint, jsonp)).to eq(base_uri)
         end
       end
     end
 
     context "when jsonp is false" do
+      let(:base_uri) { 'https://base.url/GatewayProxy/Service'}
+      before do
+        expect(client.config).to receive(:url).and_return(base_uri)
+      end
       it_behaves_like "returns url"
     end
 
     context "when jsonp is true" do
+      let(:base_uri) { 'https://base.url/GatewayProxyJSON/Service'}
+      before do
+        expect(client.config).to receive(:jsonp_url).and_return(base_uri)
+      end
       it_behaves_like "returns url", true
     end
   end
@@ -165,7 +173,7 @@ RSpec.describe VSafe::Client do
       end
 
       it "use url when jsonp url is not set" do
-        client.config.sandbox_url = 'https://sandbox.url/GatewayProxy/Service'
+        client.config.sandbox_jsonp_url = 'https://sandbox.url/GatewayProxy/Service'
         expect(client.fingerprint_url).to eq("https://sandbox.url/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
       end
 

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -195,9 +195,7 @@ RSpec.describe VSafe::Client do
       end
 
       it "uses the jsonp_url when set" do
-        allow(client.config).to receive(:sandbox_jsonp_url).and_return('https://google.com/')
-        puts "sandbox_jsonp_url:  #{client.config.sandbox_jsonp_url}"
-        puts "URL:  #{client.config.jsonp_url}  #{client.config.sandbox}"
+        client.config.sandbox_jsonp_url = 'https://google.com/'
         expect(client.fingerprint_url).to eq("https://google.com/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
       end
     end

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe VSafe::Client do
         let(:endpoint) { "foo" }
 
         it "returns endpoint url" do
-          expect(client.service_url(endpoint, jsonp)).to eq("#{client.config.url}/#{service_path}/#{endpoint}")
+          expect(client.service_url(endpoint, jsonp)).to eq("#{client.config.url}/#{endpoint}")
         end
       end
 
@@ -144,42 +144,16 @@ RSpec.describe VSafe::Client do
         let(:endpoint) { nil }
 
         it "returns base url" do
-          expect(client.service_url(endpoint, jsonp)).to eq("#{client.config.url}/#{service_path}")
+          expect(client.service_url(endpoint, jsonp)).to eq(client.config.url)
         end
       end
     end
 
     context "when jsonp is false" do
-      let(:service_path) { VSafe::Config::DEFAULT_SERVICE_PATH }
-
       it_behaves_like "returns url"
     end
 
     context "when jsonp is true" do
-      let(:service_path) { VSafe::Config::DEFAULT_JSONP_SERVICE_PATH }
-
-      it_behaves_like "returns url", true
-    end
-
-    context "when custom service_path is set" do
-      let(:service_path) { "__custom_service" }
-      let(:client) {
-        VSafe::Client.new do |config|
-          config.service_path = "__custom_service"
-        end
-      }
-
-      it_behaves_like "returns url"
-    end
-
-    context "when custom jsonp_service_path is set" do
-      let(:service_path) { "__custom_jsonp" }
-      let(:client) {
-        VSafe::Client.new do |config|
-          config.jsonp_service_path = "__custom_jsonp"
-        end
-      }
-
       it_behaves_like "returns url", true
     end
   end
@@ -190,8 +164,9 @@ RSpec.describe VSafe::Client do
         allow(client.config).to receive(:sandbox).and_return(true)
       end
 
-      it "returns url" do
-        expect(client.fingerprint_url).to eq("#{client.config.jsonp_url}/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
+      it "use url when jsonp url is not set" do
+        client.config.sandbox_url = 'https://sandbox.url/GatewayProxy/Service'
+        expect(client.fingerprint_url).to eq("https://sandbox.url/#{VSafe::Client::SANDBOX_FINGERPRINT_PATH}")
       end
 
       it "uses the jsonp_url when set" do

--- a/spec/vsafe/config_spec.rb
+++ b/spec/vsafe/config_spec.rb
@@ -43,12 +43,7 @@ RSpec.describe VSafe::Config do
   describe "#jsonp_url" do
     context "sandbox is true" do
       it "uses default sandbox_url" do
-        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
-      end
-
-      it "uses sandbox_url if sandbox_jsonp_url is not set" do
-        config.sandbox_url = "https://www.google.com"
-        expect(config.jsonp_url).to eq("https://www.google.com")
+        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_JSONP_URL)
       end
 
       it "uses custom sandbox_jsonp_url when set" do
@@ -62,15 +57,6 @@ RSpec.describe VSafe::Config do
         config.sandbox = false
       end
 
-      it "uses default production_url when not set" do
-        expect(config.url).to eq(VSafe::Config::DEFAULT_PRODUCTION_URL)
-      end
-
-      it "uses production_url if production_jsonp_url is not set" do
-        config.production_url = "https://www.google.com"
-        expect(config.jsonp_url).to eq("https://www.google.com")
-      end
-
       it "uses custom production_url when not sandbox" do
         config.production_jsonp_url = "https://www.googlesandbox.com"
         expect(config.jsonp_url).to eq("https://www.googlesandbox.com")
@@ -81,12 +67,7 @@ RSpec.describe VSafe::Config do
   describe "#jsonp_url" do
     context "sandbox is true" do
       it "uses default sandbox_url" do
-        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
-      end
-
-      it "uses sandbox_url if sandbox_jsonp_url is not set" do
-        config.sandbox_url = "https://www.google.com"
-        expect(config.jsonp_url).to eq("https://www.google.com")
+        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_JSONP_URL)
       end
 
       it "uses custom sandbox_jsonp_url when set" do

--- a/spec/vsafe/config_spec.rb
+++ b/spec/vsafe/config_spec.rb
@@ -3,7 +3,7 @@ require "vsafe/config"
 
 RSpec.describe VSafe::Config do
   let (:config) { VSafe::Config.new }
-  
+
   describe ".new" do
     it "sets default configs" do
       expect(config.sandbox).to eq(true)
@@ -11,31 +11,87 @@ RSpec.describe VSafe::Config do
       expect(config.url).not_to be_empty
     end
   end
-  
+
   describe "#url" do
     context "sandbox is true" do
       it "uses default sandbox_url" do
         expect(config.url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
       end
-      
+
       it "uses custom sandbox_url when sandbox" do
         config.sandbox_url = "https://www.google.com"
         expect(config.url).to eq("https://www.google.com")
       end
     end
-    
+
     context "sandbox is not true" do
       before do
         config.sandbox = false
       end
-      
+
       it "uses default production_url when not sandbox" do
         expect(config.url).to eq(VSafe::Config::DEFAULT_PRODUCTION_URL)
       end
-      
+
       it "uses custom production_url when not sandbox" do
         config.production_url = "https://www.google.com"
         expect(config.url).to eq("https://www.google.com")
+      end
+    end
+  end
+
+  describe "#jsonp_url" do
+    context "sandbox is true" do
+      it "uses default sandbox_url" do
+        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
+      end
+
+      it "uses sandbox_url if sandbox_jsonp_url is not set" do
+        config.sandbox_url = "https://www.google.com"
+        expect(config.jsonp_url).to eq("https://www.google.com")
+      end
+
+      it "uses custom sandbox_jsonp_url when set" do
+        config.sandbox_jsonp_url = "https://www.googlesandbox.com"
+        expect(config.jsonp_url).to eq("https://www.googlesandbox.com")
+      end
+    end
+
+    context "sandbox is not true" do
+      before do
+        config.sandbox = false
+      end
+
+      it "uses default production_url when not set" do
+        expect(config.url).to eq(VSafe::Config::DEFAULT_PRODUCTION_URL)
+      end
+
+      it "uses production_url if production_jsonp_url is not set" do
+        config.production_url = "https://www.google.com"
+        expect(config.jsonp_url).to eq("https://www.google.com")
+      end
+
+      it "uses custom production_url when not sandbox" do
+        config.production_jsonp_url = "https://www.googlesandbox.com"
+        expect(config.jsonp_url).to eq("https://www.googlesandbox.com")
+      end
+    end
+  end
+
+  describe "#jsonp_url" do
+    context "sandbox is true" do
+      it "uses default sandbox_url" do
+        expect(config.jsonp_url).to eq(VSafe::Config::DEFAULT_SANDBOX_URL)
+      end
+
+      it "uses sandbox_url if sandbox_jsonp_url is not set" do
+        config.sandbox_url = "https://www.google.com"
+        expect(config.jsonp_url).to eq("https://www.google.com")
+      end
+
+      it "uses custom sandbox_jsonp_url when set" do
+        config.sandbox_jsonp_url = "https://www.googlesandbox.com"
+        expect(config.jsonp_url).to eq("https://www.googlesandbox.com")
       end
     end
   end


### PR DESCRIPTION
Vesta recently changed their URL configs for the sandbox, so the JSON and JSONP URLs have different domains. Since there are now 4 possible URL combos, its easier to just allow explicitly setting the URLs instead of having the underlying system join paths. 

A typical setup might look something like this now:
```
VSafe.configure do |config|
  config.sandbox_url = 'https://sanboxdomain.com/GatewayProxy/Service'
  config.sandbox_jsonp_url  = 'https://sandbox-otherdomain.com/GatewayProxyJSON/Service'
  config.production_url = ''https://production.com/GatewayProxyJSON/Service'
  config.production_jsonp_url = ''https://production.com/GatewayProxyJSON/Service'
  config.logger = Rails.logger
end
```

I setup all the URLs based on the previous defaults, so if Vesta hasn't changed your URLs this should just work for you.

This PR also adds the option to pass a logger down to HTTParty. Doing `config.logger = Rails.logger` will set the HTTParty logger when making requests and give nice request/response logging.