### PR TITLE
Add GetPaymentStatus Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ response.payment_id
 response.payment_status
 ```
 
+##### Get Payment Status
+
+Get the payment status by the partner transaction ID or Vesta Payment ID.
+
+```ruby
+params = {
+  PartnerTransactionID: '333c1b85-c5db-4648-a946-ba408582fc1c'
+}
+response = client.get_payment_status(params) # => #<VSafe::Responses::GetPaymentStatus ...>
+
+# Response attributes
+response.amount
+response.payment_id
+response.payment_status
+response.response_code
+response.transaction_id
+```
+
+Note: If transaction does not exist on Vesta, result of `response.success?` will be false.
 
 ## Contributing
 

--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -8,6 +8,7 @@ require "vsafe/responses/reverse_payment"
 require "vsafe/responses/charge_account_to_temporary_token"
 require "vsafe/responses/charge_sale"
 require "vsafe/responses/validate_charge_account"
+require "vsafe/responses/get_payment_status"
 require "securerandom"
 require "uri"
 
@@ -58,6 +59,10 @@ module VSafe
       VSafe::Responses::ValidateChargeAccount.new(request(service_url("ValidateChargeAccount"), params))
     end
 
+    def get_payment_status(params)
+      VSafe::Responses::GetPaymentStatus.new(request(service_url("GetPaymentStatus"), params))
+    end
+
     def service_url(endpoint = nil, jsonp = false)
       base_uri = jsonp ? config.jsonp_url : config.url
       endpoint.nil? ? base_uri : File.join(base_uri, endpoint)
@@ -89,7 +94,7 @@ module VSafe
         options[:ssl_version] = :TLSv1
       end
 
-      response = HTTParty.post(url, options)
+      HTTParty.post(url, options)
     end
   end
 end

--- a/lib/vsafe/responses/get_payment_status.rb
+++ b/lib/vsafe/responses/get_payment_status.rb
@@ -5,7 +5,7 @@ module VSafe
     class GetPaymentStatus < Response
       define_attribute_mapping(:amount, "Amount")
       define_attribute_mapping(:payment_id, "PaymentID")
-      define_attribute_mapping(:payment_status, "PaymentStatus")
+      define_attribute_mapping(:payment_status, "PaymentStatus", PaymentStatus)
       define_attribute_mapping(:response_code, "ResponseCode")
       define_attribute_mapping(:transaction_id, "TransactionID")
     end

--- a/lib/vsafe/responses/get_payment_status.rb
+++ b/lib/vsafe/responses/get_payment_status.rb
@@ -1,0 +1,13 @@
+require "vsafe/response"
+
+module VSafe
+  module Responses
+    class GetPaymentStatus < Response
+      define_attribute_mapping(:amount, "Amount")
+      define_attribute_mapping(:payment_id, "PaymentID")
+      define_attribute_mapping(:payment_status, "PaymentStatus")
+      define_attribute_mapping(:response_code, "ResponseCode")
+      define_attribute_mapping(:transaction_id, "TransactionID")
+    end
+  end
+end

--- a/lib/vsafe/version.rb
+++ b/lib/vsafe/version.rb
@@ -1,3 +1,3 @@
 module VSafe
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/vsafe/client_spec.rb
+++ b/spec/vsafe/client_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe VSafe::Client do
     end
   end
 
+  describe "#get_payment_status" do
+    it "returns response" do
+      stub_vsafe_request("GetPaymentStatus")
+      response = client.get_payment_status(params)
+
+      expect(response).to be_a(VSafe::Responses::GetPaymentStatus)
+      expect(response).to be_success
+    end
+  end
+
   describe "#service_url" do
     shared_examples_for "returns url" do |jsonp|
       context "when endpoint defined" do

--- a/spec/vsafe/responses/get_payment_status_spec.rb
+++ b/spec/vsafe/responses/get_payment_status_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe VSafe::Responses::GetPaymentStatus do
   it { is_expected.to have_attributes(response_code: '0') }
   it { is_expected.to have_attributes(amount: '5.0000') }
   it { is_expected.to have_attributes(payment_id: '1234') }
-  it { is_expected.to have_attributes(payment_status: '3') }
   it { is_expected.to have_attributes(transaction_id: '23') }
+  it 'should have correct payment status code' do
+    expect(response.payment_status.code).to eq(3)
+  end
 end

--- a/spec/vsafe/responses/get_payment_status_spec.rb
+++ b/spec/vsafe/responses/get_payment_status_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "vsafe/responses/get_session_tags"
+
+RSpec.describe VSafe::Responses::GetPaymentStatus do
+  let(:success_body) {
+    {
+      "ResponseCode" => "0",
+      "Amount" => "5.0000",
+      "PaymentID" => "1234",
+      "PaymentStatus" => "3",
+      "TransactionID" => "23",
+    }
+  }
+  let(:http_response) { double(:response, success?: true, parsed_response: success_body) }
+  subject(:response) { VSafe::Responses::GetPaymentStatus.new(http_response) }
+
+  it { is_expected.to have_attributes(response_code: '0') }
+  it { is_expected.to have_attributes(amount: '5.0000') }
+  it { is_expected.to have_attributes(payment_id: '1234') }
+  it { is_expected.to have_attributes(payment_status: '3') }
+  it { is_expected.to have_attributes(transaction_id: '23') }
+end

--- a/spec/vsafe/responses/get_session_tags_spec.rb
+++ b/spec/vsafe/responses/get_session_tags_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VSafe::Responses::GetSessionTags do
   let(:success_body) {
     {
       "OrgID" => org_id,
-      "WebSessionID" => "test_web_session_id"
+      "WebSessionID" => web_session_id
     }
   }
   let(:http_response) { double(:response, success?: true, parsed_response: success_body) }


### PR DESCRIPTION
This PR adds the functionality for calling GetPaymentStatus endpoint of Vesta.

This is useful to get more information about a transaction if Vesta clients get a timeout or any network error.

@maintainers: please do let me know if I'm missing anything here, or if you have any feedback.
Thanks