### PR TITLE
Setting Sandbox SSL version to TLSv1 is not needed anymore

### DIFF
--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -88,12 +88,6 @@ module VSafe
         logger: @config.logger
       }
 
-      # The HTTPS endpoint for VSafe Sandbox has an outdated SSL version.
-      # We need to do this so that we can actually connect.
-      if config.sandbox
-        options[:ssl_version] = :TLSv1
-      end
-
       HTTParty.post(url, options)
     end
   end

--- a/lib/vsafe/version.rb
+++ b/lib/vsafe/version.rb
@@ -1,3 +1,3 @@
 module VSafe
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
Vesta might have changed their server setup, this config is breaking the requests right now.

Tested w/o setting the SSL version, and worked as expected.