### PR TITLE
remove ssl TLSv1 version constraint for sandbox

### DIFF
--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -88,12 +88,6 @@ module VSafe
         logger: @config.logger
       }
 
-      # The HTTPS endpoint for VSafe Sandbox has an outdated SSL version.
-      # We need to do this so that we can actually connect.
-      if config.sandbox
-        options[:ssl_version] = :TLSv1
-      end
-
       HTTParty.post(url, options)
     end
   end


### PR DESCRIPTION
currently, on sandbox env returns:
`#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=unknown state: sslv3 alert handshake failure>` for `get_session_tags`

when removing the ssl constraint, I am able to get a response